### PR TITLE
fix: load images after default filter is set

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -12,6 +12,7 @@ function love.load()
     math.randomseed(os.time())
     love.window.setTitle('Legend of Zelda')
     love.graphics.setDefaultFilter('nearest', 'nearest')
+    loadDependencies()
 
     push:setupScreen(VIRTUAL_WIDTH, VIRTUAL_HEIGHT, WINDOW_WIDTH, WINDOW_HEIGHT, {
         fullscreen = false,

--- a/src/Dependencies.lua
+++ b/src/Dependencies.lua
@@ -35,39 +35,46 @@ require 'src/states/game/GameOverState'
 require 'src/states/game/PlayState'
 require 'src/states/game/StartState'
 
-gTextures = {
-    ['tiles'] = love.graphics.newImage('graphics/tilesheet.png'),
-    ['background'] = love.graphics.newImage('graphics/background.png'),
-    ['character-walk'] = love.graphics.newImage('graphics/character_walk.png'),
-    ['character-swing-sword'] = love.graphics.newImage('graphics/character_swing_sword.png'),
-    ['hearts'] = love.graphics.newImage('graphics/hearts.png'),
-    ['switches'] = love.graphics.newImage('graphics/switches.png'),
-    ['entities'] = love.graphics.newImage('graphics/entities.png')
-}
+gTextures = {}
+gFrames = {}
+gFonts = {}
 
-gFrames = {
-    ['tiles'] = GenerateQuads(gTextures['tiles'], 16, 16),
-    ['character-walk'] = GenerateQuads(gTextures['character-walk'], 16, 32),
-    ['character-swing-sword'] = GenerateQuads(gTextures['character-swing-sword'], 32, 32),
-    ['entities'] = GenerateQuads(gTextures['entities'], 16, 16),
-    ['hearts'] = GenerateQuads(gTextures['hearts'], 16, 16),
-    ['switches'] = GenerateQuads(gTextures['switches'], 16, 18)
-}
-
-gFonts = {
-    ['small'] = love.graphics.newFont('fonts/font.ttf', 8),
-    ['medium'] = love.graphics.newFont('fonts/font.ttf', 16),
-    ['large'] = love.graphics.newFont('fonts/font.ttf', 32),
-    ['gothic-medium'] = love.graphics.newFont('fonts/GothicPixels.ttf', 16),
-    ['gothic-large'] = love.graphics.newFont('fonts/GothicPixels.ttf', 32),
-    ['zelda'] = love.graphics.newFont('fonts/zelda.otf', 64),
-    ['zelda-small'] = love.graphics.newFont('fonts/zelda.otf', 32)
-}
-
-gSounds = {
-    ['music'] = love.audio.newSource('sounds/music.mp3', 'static'),
-    ['sword'] = love.audio.newSource('sounds/sword.wav', 'static'),
-    ['hit-enemy'] = love.audio.newSource('sounds/hit_enemy.wav', 'static'),
-    ['hit-player'] = love.audio.newSource('sounds/hit_player.wav', 'static'),
-    ['door'] = love.audio.newSource('sounds/door.wav', 'static')
-}
+-- load dependencies 
+function loadDependencies()
+    gTextures = {
+        ['tiles'] = love.graphics.newImage('graphics/tilesheet.png'),
+        ['background'] = love.graphics.newImage('graphics/background.png'),
+        ['character-walk'] = love.graphics.newImage('graphics/character_walk.png'),
+        ['character-swing-sword'] = love.graphics.newImage('graphics/character_swing_sword.png'),
+        ['hearts'] = love.graphics.newImage('graphics/hearts.png'),
+        ['switches'] = love.graphics.newImage('graphics/switches.png'),
+        ['entities'] = love.graphics.newImage('graphics/entities.png')
+    }
+    
+    gFrames = {
+        ['tiles'] = GenerateQuads(gTextures['tiles'], 16, 16),
+        ['character-walk'] = GenerateQuads(gTextures['character-walk'], 16, 32),
+        ['character-swing-sword'] = GenerateQuads(gTextures['character-swing-sword'], 32, 32),
+        ['entities'] = GenerateQuads(gTextures['entities'], 16, 16),
+        ['hearts'] = GenerateQuads(gTextures['hearts'], 16, 16),
+        ['switches'] = GenerateQuads(gTextures['switches'], 16, 18)
+    }
+    
+    gFonts = {
+        ['small'] = love.graphics.newFont('fonts/font.ttf', 8),
+        ['medium'] = love.graphics.newFont('fonts/font.ttf', 16),
+        ['large'] = love.graphics.newFont('fonts/font.ttf', 32),
+        ['gothic-medium'] = love.graphics.newFont('fonts/GothicPixels.ttf', 16),
+        ['gothic-large'] = love.graphics.newFont('fonts/GothicPixels.ttf', 32),
+        ['zelda'] = love.graphics.newFont('fonts/zelda.otf', 64),
+        ['zelda-small'] = love.graphics.newFont('fonts/zelda.otf', 32)
+    }
+    
+    gSounds = {
+        ['music'] = love.audio.newSource('sounds/music.mp3', 'static'),
+        ['sword'] = love.audio.newSource('sounds/sword.wav', 'static'),
+        ['hit-enemy'] = love.audio.newSource('sounds/hit_enemy.wav', 'static'),
+        ['hit-player'] = love.audio.newSource('sounds/hit_player.wav', 'static'),
+        ['door'] = love.audio.newSource('sounds/door.wav', 'static')
+    }
+end


### PR DESCRIPTION
**Problem**

All images are blurry because dependencies were read before the default filter set

**Solution**

Wrap dependencies in a function and call it after setDefaultFilter

<img width="1281" alt="image" src="https://user-images.githubusercontent.com/22411825/183390930-1181a558-a3e5-4bf6-8900-973df2fc6d55.png">

<img width="1279" alt="image" src="https://user-images.githubusercontent.com/22411825/183391164-d682a76b-73d9-42d8-922e-18753307643c.png">
